### PR TITLE
Fix missing auth constant

### DIFF
--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,0 +1,1 @@
+export const AUTH_COOKIE = 'auth-token'


### PR DESCRIPTION
## Summary
- add missing `AUTH_COOKIE` constant

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68915a0de1b083228f8b6118f7a694ec