### PR TITLE
Allow login API and use AUTH env vars

### DIFF
--- a/api/login/route.ts
+++ b/api/login/route.ts
@@ -7,8 +7,8 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const { email, password } = body
 
-  const validEmail = process.env.APP_EMAIL
-  const validPassword = process.env.APP_PASSWORD
+  const validEmail = process.env.AUTH_EMAIL
+  const validPassword = process.env.AUTH_PASSWORD
 
   // Empty field check (should be prevented client-side but safe here too)
   if (!email || !password) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,11 +4,12 @@ import { AUTH_COOKIE } from '@/lib/auth'
 export function middleware(request: NextRequest) {
   const token = request.cookies.get(AUTH_COOKIE)?.value
 
-  // Allow access to login page or static files
+  // Allow access to login page, login API, or static files
   const isLoginPage = request.nextUrl.pathname === '/login'
+  const isLoginApi = request.nextUrl.pathname === '/api/login'
   const isPublicFile = /\.(.*)$/.test(request.nextUrl.pathname)
 
-  if (token || isLoginPage || isPublicFile) {
+  if (token || isLoginPage || isLoginApi || isPublicFile) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Summary
- Permit `/api/login` requests through middleware to reach login endpoint
- Use `AUTH_EMAIL` and `AUTH_PASSWORD` for credential validation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68915feff65c8322bb42b20cbe9816af